### PR TITLE
cv_dv_utils: Fix atomic and exclusive access handling in memory response model

### DIFF
--- a/lib/cv_dv_utils/uvm/memory_rsp_model/axi2mem/axi2mem.svh
+++ b/lib/cv_dv_utils/uvm/memory_rsp_model/axi2mem/axi2mem.svh
@@ -339,34 +339,34 @@ class axi2mem#(int unsigned w_addr = 0,  int unsigned w_data = 0, int unsigned w
                case(req.aw_chan.atop[2:0])
                  AXI_ATOMIC_ADD   : mem_wr_vif.amo_op = MEM_ATOMIC_ADD ;
                  AXI_ATOMIC_CLR   : mem_wr_vif.amo_op = MEM_ATOMIC_CLR ;
-                 AXI_ATOMIC_EOR   : mem_wr_vif.amo_op = MEM_ATOMIC_SET ;
-                 AXI_ATOMIC_SET   : mem_wr_vif.amo_op = MEM_ATOMIC_EOR ;
+                 AXI_ATOMIC_EOR   : mem_wr_vif.amo_op = MEM_ATOMIC_EOR ;
+                 AXI_ATOMIC_SET   : mem_wr_vif.amo_op = MEM_ATOMIC_SET ;
                  AXI_ATOMIC_SMAX  : mem_wr_vif.amo_op = MEM_ATOMIC_SMAX;
                  AXI_ATOMIC_SMIN  : mem_wr_vif.amo_op = MEM_ATOMIC_SMIN;
                  AXI_ATOMIC_UMAX  : mem_wr_vif.amo_op = MEM_ATOMIC_UMAX;
                  AXI_ATOMIC_UMIN  : mem_wr_vif.amo_op = MEM_ATOMIC_UMIN;
                endcase  
-               q_num_ar_chan_req[req.aw_chan.id].push_back(0);
              end
              AXI_ATOMIC_LOAD   : begin
                // Requires a read response 
                mem_wr_vif.req_amo = 1;  
-               mem_wr_vif.req_wrn = 0;
+               mem_wr_vif.req_wrn = 1;
                case(req.aw_chan.atop[2:0])
                  AXI_ATOMIC_ADD   : mem_wr_vif.amo_op = MEM_ATOMIC_ADD ;
                  AXI_ATOMIC_CLR   : mem_wr_vif.amo_op = MEM_ATOMIC_CLR ;
-                 AXI_ATOMIC_EOR   : mem_wr_vif.amo_op = MEM_ATOMIC_SET ;
-                 AXI_ATOMIC_SET   : mem_wr_vif.amo_op = MEM_ATOMIC_EOR ;
+                 AXI_ATOMIC_EOR   : mem_wr_vif.amo_op = MEM_ATOMIC_EOR ;
+                 AXI_ATOMIC_SET   : mem_wr_vif.amo_op = MEM_ATOMIC_SET ;
                  AXI_ATOMIC_SMAX  : mem_wr_vif.amo_op = MEM_ATOMIC_SMAX;
                  AXI_ATOMIC_SMIN  : mem_wr_vif.amo_op = MEM_ATOMIC_SMIN;
                  AXI_ATOMIC_UMAX  : mem_wr_vif.amo_op = MEM_ATOMIC_UMAX;
                  AXI_ATOMIC_UMIN  : mem_wr_vif.amo_op = MEM_ATOMIC_UMIN;
                endcase              
+               q_num_ar_chan_req[req.aw_chan.id].push_back(0);
              end
              AXI_ATOMIC_OTHERS : begin
                // Requires a read response 
                mem_wr_vif.req_amo = 1;  
-               mem_wr_vif.req_wrn = 0;
+               mem_wr_vif.req_wrn = 1;
                case(req.aw_chan.atop[3:0])
                  AXI_ATOMIC_SWAP : mem_wr_vif.amo_op = MEM_ATOMIC_SWAP;
                  AXI_ATOMIC_CMP  : mem_wr_vif.amo_op = MEM_ATOMIC_CMP;                
@@ -378,7 +378,7 @@ class axi2mem#(int unsigned w_addr = 0,  int unsigned w_data = 0, int unsigned w
   
            if(req.aw_chan.lock == 1) begin 
              mem_wr_vif.amo_op    = MEM_ATOMIC_STEX;
-             mem_rd_vif.req_amo   = 1;
+             mem_wr_vif.req_amo   = 1;
            end
            do begin
              @ (posedge mem_wr_vif.clk);

--- a/lib/cv_dv_utils/uvm/memory_rsp_model/memory_response_model.svh
+++ b/lib/cv_dv_utils/uvm/memory_rsp_model/memory_response_model.svh
@@ -647,15 +647,9 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            // WRITE
            // --> If true, remove the reservation 
            // --------------------------------------------------------
-           foreach(m_mem_rsp_vif.req_strb[i]) begin
-             if(m_mem_rsp_vif.req_strb[i] == 1) begin
-               if(m_memory[req_addr].ldex_bytes.exists(m_mem_rsp_vif.src_id)) begin
-                 if( m_memory[req_addr].ldex_bytes[m_mem_rsp_vif.src_id][i] == 1) begin
-                   m_memory[req_addr].ldex_bytes.delete(m_mem_rsp_vif.src_id);
-                   break;
-                 end
-               end
-             end
+           foreach(m_memory[req_addr].ldex_bytes[i]) begin
+             if(|(m_memory[req_addr].ldex_bytes[i] & m_mem_rsp_vif.req_strb))
+               m_memory[req_addr].ldex_bytes.delete(i);
            end
            // --------------------------------------------------------
            // Generate new response with delay for the incoming transaction 
@@ -729,7 +723,7 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
   
    // -----------------------------------------------------------------
    // In the case of AMO : 
-   //  ->Two response read and write are expected
+   //  ->Two response read and write are expected when req_wrn is set
    //  -> Except for LDEX/STEX 
    // ----------------------------------------------------------------
    virtual task populate_amo_rd_wr_rsp_queue();
@@ -815,9 +809,10 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            new_rd_rsp_entry.data     = m_memory[req_addr].data;
 
            // --------------------------------------------------
-           // In case of ATOMIC STEX , do not send read response
+           // In case of ATOMIC STORE/STEX, do not send read response
            // --------------------------------------------------
-           if(!(m_mem_rsp_vif.amo_op == MEM_ATOMIC_STEX)) begin
+           if((m_mem_rsp_vif.req_wrn) &&
+              !(m_mem_rsp_vif.amo_op == MEM_ATOMIC_STEX)) begin
 
              new_rd_rsp_entry.id         = m_mem_rsp_vif.req_id;
              // ---------------------------------------------
@@ -883,9 +878,55 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
        
              q_index1.delete();
              q_index.delete();
-           end // !MEM_ATOMIC_STEX
+           end
+           if(m_mem_rsp_vif.amo_op == MEM_ATOMIC_STEX) begin
+             new_wr_rsp_entry            = new();
+             new_wr_rsp_entry.id         = m_mem_rsp_vif.req_id;
+             new_wr_rsp_entry.ex_fail     = 0;
+
+             // ----------------------------------------------------
+             // If error exclusive flag is set
+             // ----------------------------------------------------
+             if(m_rsp_cfg.insert_wr_exclusive_fail) begin
+                if(wr_rsp_exclusive_fail_counter < m_rsp_cfg.num_wr_exclusive_fails) begin
+                    new_wr_rsp_entry.ex_fail     = ($urandom_range(0, 5) == 2) ? 1: 0 ;
+                    `uvm_info("MEMORY RESPONSE MODEL", $sformatf("Inserted SC Exclusive Error %d", new_wr_rsp_entry.ex_fail), UVM_FULL);
+                    if(new_wr_rsp_entry.ex_fail)  wr_rsp_exclusive_fail_counter++;
+               end
+             end
+
+             // --------------------------------------------------------
+             // In the case of STEX,
+             // check if reservation exists for the same byte accessed by
+             // STEX
+             // --------------------------------------------------------
+             if(m_memory[req_addr].ldex_bytes.exists(m_mem_rsp_vif.src_id)) begin
+               foreach(m_mem_rsp_vif.req_strb[i]) begin
+                 if(m_mem_rsp_vif.req_strb[i] == 1) begin
+                   if( m_memory[req_addr].ldex_bytes[m_mem_rsp_vif.src_id][i] == 0) begin
+                     new_wr_rsp_entry.ex_fail = 1;
+                    `uvm_info("MEMORY RESPONSE MODEL", $sformatf("SC FAILED %s", new_wr_rsp_entry.convert2string()), UVM_FULL);
+                   end
+                 end
+               end
+             end else begin
+               new_wr_rsp_entry.ex_fail = 1;
+             end
+             m_memory[req_addr].ldex_bytes.delete(m_mem_rsp_vif.src_id);
+           end // MEM_ATOMIC_STEX
            
            
+           // --------------------------------------------------------
+           // For any other access remove the reservation
+           // --------------------------------------------------------
+           if((m_mem_rsp_vif.amo_op != MEM_ATOMIC_LDEX) &&
+              (m_mem_rsp_vif.amo_op != MEM_ATOMIC_STEX)) begin
+             foreach(m_memory[req_addr].ldex_bytes[i]) begin
+               if(|(m_memory[req_addr].ldex_bytes[i] & m_mem_rsp_vif.req_strb))
+                 m_memory[req_addr].ldex_bytes.delete(i);
+             end
+           end
+
            wr_stb  = m_mem_rsp_vif.req_strb;
            wr_data = m_mem_rsp_vif.req_data;
 
@@ -915,7 +956,7 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
 
              if(wr_stb[k] == 1'b1) begin
                case(m_mem_rsp_vif.amo_op)
-                 MEM_ATOMIC_STEX :     m_memory[req_addr].data[8*k +: 8]    =       wr_data[8*k +: 8]                                ; 
+                 MEM_ATOMIC_STEX :     if(!new_wr_rsp_entry.ex_fail) m_memory[req_addr].data[8*k +: 8]    =       wr_data[8*k +: 8]                                ;
                  MEM_ATOMIC_CLR  :     m_memory[req_addr].data[8*k +: 8]    =      ~wr_data[8*k +: 8] & m_memory[req_addr].data[8*k +: 8];
                  MEM_ATOMIC_SET  :     m_memory[req_addr].data[8*k +: 8]    =       wr_data[8*k +: 8] | m_memory[req_addr].data[8*k +: 8];
                  MEM_ATOMIC_EOR  :     m_memory[req_addr].data[8*k +: 8]    =       wr_data[8*k +: 8] ^ m_memory[req_addr].data[8*k +: 8];
@@ -980,42 +1021,12 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            // In case of ATOMIC LDEX do not send write response
            // --------------------------------------------------------
            if(!(m_mem_rsp_vif.amo_op == MEM_ATOMIC_LDEX)) begin
-              new_wr_rsp_entry            = new();
-              new_wr_rsp_entry.id         = m_mem_rsp_vif.req_id;
-              new_wr_rsp_entry.ex_fail     = 0;
-
-              // --------------------------------------------------------
-              // In the case of STEX,
-              // check if reservation exists for the same byte accessed by
-              // STEX
-              // For any other access remove the reservation 
-              // --------------------------------------------------------
-              if(m_memory[req_addr].ldex_bytes.exists(m_mem_rsp_vif.src_id)) begin
-                if(m_mem_rsp_vif.amo_op == MEM_ATOMIC_STEX) begin
-                  foreach(m_mem_rsp_vif.req_strb[i]) begin
-                    if(m_mem_rsp_vif.req_strb[i] == 1) begin
-                      if( m_memory[req_addr].ldex_bytes[m_mem_rsp_vif.src_id][i] == 0) begin
-                        new_wr_rsp_entry.ex_fail = 1;
-                       `uvm_info("MEMORY RESPONSE MODEL", $sformatf("SC FAILED %s", new_wr_rsp_entry.convert2string()), UVM_FULL);
-                      end
-                    end
-                  end
-                  m_memory[req_addr].ldex_bytes.delete(m_mem_rsp_vif.src_id);
-                end
+              if(!(m_mem_rsp_vif.amo_op == MEM_ATOMIC_STEX)) begin
+                new_wr_rsp_entry            = new();
+                new_wr_rsp_entry.id         = m_mem_rsp_vif.req_id;
+                new_wr_rsp_entry.ex_fail     = 0;
               end
 
-              if(m_mem_rsp_vif.amo_op ==  MEM_ATOMIC_STEX) begin
-                // ----------------------------------------------------
-                // If error exclusive flag is set
-                // ----------------------------------------------------
-                if(m_rsp_cfg.insert_wr_exclusive_fail) begin
-                   if(wr_rsp_exclusive_fail_counter < m_rsp_cfg.num_wr_exclusive_fails) begin
-                       new_wr_rsp_entry.ex_fail     = ($urandom_range(0, 5) == 2) ? 1: 0 ;
-                       `uvm_info("MEMORY RESPONSE MODEL", $sformatf("Inserted SC Exclusive Error %d", new_wr_rsp_entry.ex_fail), UVM_FULL);
-                   end
-                   if(new_wr_rsp_entry.ex_fail)  wr_rsp_exclusive_fail_counter++;
-                end
-              end
               // ----------------------------------------------------
               // If error flag is set
               // -> Send AMO write error response

--- a/lib/cv_dv_utils/uvm/memory_rsp_model/memory_response_model.svh
+++ b/lib/cv_dv_utils/uvm/memory_rsp_model/memory_response_model.svh
@@ -596,6 +596,7 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
        // -----------------------------------------
        int                         q_index[$];
        int                         q_index1[$];
+       integer                     ldex_q_index[$];
 
        // -----------------------------------------
        // New node to m_memory list 
@@ -647,10 +648,11 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            // WRITE
            // --> If true, remove the reservation 
            // --------------------------------------------------------
-           foreach(m_memory[req_addr].ldex_bytes[i]) begin
-             if(|(m_memory[req_addr].ldex_bytes[i] & m_mem_rsp_vif.req_strb))
-               m_memory[req_addr].ldex_bytes.delete(i);
-           end
+           ldex_q_index = m_memory[req_addr].ldex_bytes.find_index(item) with
+                          (|(item & m_mem_rsp_vif.req_strb));
+           foreach(ldex_q_index[i])
+             m_memory[req_addr].ldex_bytes.delete(ldex_q_index[i]);
+           ldex_q_index.delete();
            // --------------------------------------------------------
            // Generate new response with delay for the incoming transaction 
            // --------------------------------------------------------
@@ -733,6 +735,7 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
        // -----------------------------------------
        int                         q_index[$];
        int                         q_index1[$];
+       integer                     ldex_q_index[$];
 
        // -----------------------------------------
        // New node to m_memory list 
@@ -799,7 +802,7 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            // Remove previous lock 
            // -------------------------------------------------------
            if(m_mem_rsp_vif.amo_op == MEM_ATOMIC_LDEX) begin
-             foreach(m_memory[req_addr].ldex_bytes[i]) m_memory[req_addr].ldex_bytes.delete(i);
+             m_memory[req_addr].ldex_bytes.delete();
              m_memory[req_addr].ldex_bytes[m_mem_rsp_vif.src_id] = m_mem_rsp_vif.req_strb; 
            end
            // --------------------------------------------------
@@ -921,10 +924,11 @@ class memory_response_model#(int w_addr = 64, int w_data = 512, int w_id = 16)  
            // --------------------------------------------------------
            if((m_mem_rsp_vif.amo_op != MEM_ATOMIC_LDEX) &&
               (m_mem_rsp_vif.amo_op != MEM_ATOMIC_STEX)) begin
-             foreach(m_memory[req_addr].ldex_bytes[i]) begin
-               if(|(m_memory[req_addr].ldex_bytes[i] & m_mem_rsp_vif.req_strb))
-                 m_memory[req_addr].ldex_bytes.delete(i);
-             end
+             ldex_q_index = m_memory[req_addr].ldex_bytes.find_index(item) with
+                            (|(item & m_mem_rsp_vif.req_strb));
+             foreach(ldex_q_index[i])
+               m_memory[req_addr].ldex_bytes.delete(ldex_q_index[i]);
+             ldex_q_index.delete();
            end
 
            wr_stb  = m_mem_rsp_vif.req_strb;


### PR DESCRIPTION
### Description

This PR fixes several correctness issues in AXI atomic/exclusive translation and in the `memory_rsp_model` handling of atomic responses and exclusive reservations.

### Changes

#### `axi2mem`

* Fix the swapped mappings of `AXI_ATOMIC_EOR` and `AXI_ATOMIC_SET`.
* Fix the response handling for AXI atomic transactions:

  * `AtomicStore` does not generate a read response.
  * `AtomicLoad`, `AtomicSwap`, and `AtomicCompare` are marked as requiring a read response and are tracked accordingly.
* Fix AXI exclusive writes so that STEX is marked as an atomic request on `mem_wr_vif` instead of `mem_rd_vif`.

#### `memory_rsp_model`

* Fix exclusive reservation invalidation for writes and non-exclusive atomic operations. An access now invalidates all overlapping reservations, regardless of the `src_id` that created them.
* Evaluate the STEX result before modifying memory:

  * STEX fails if there is no reservation for the requesting `src_id`.
  * STEX fails if any accessed byte is not covered by the reservation.
  * Injected exclusive failures are applied before the memory update.
  * Memory is updated only when STEX succeeds.

Previously, the model could report a failed exclusive store while still updating its internal memory, and conflicting accesses only invalidated reservations associated with their own `src_id`.

Thanks.
